### PR TITLE
Add support for scoped external imports

### DIFF
--- a/src/compareImports.test.js
+++ b/src/compareImports.test.js
@@ -3,15 +3,7 @@ import compareImports, {
   sanitizeOrder,
   compareByMatcher,
 } from './compareImports';
-
-const DEFAULT_ORDER = [
-  'builtin',
-  'external',
-  'internal',
-  'parent',
-  'sibling',
-  'index',
-];
+import { DEFAULT_ORDER } from './constants';
 
 test('sanitizeOrder should leave default order unchanged', t => {
   t.deepEqual(sanitizeOrder(DEFAULT_ORDER), DEFAULT_ORDER);
@@ -20,11 +12,22 @@ test('sanitizeOrder should leave default order unchanged', t => {
 test('sanitizeOrder should append all omitted groups', t => {
   t.deepEqual(sanitizeOrder(['external']), [
     'external',
-    ['builtin', 'internal', 'parent', 'sibling', 'index'].sort(),
+    [
+      'builtin',
+      'internal',
+      'parent',
+      'sibling',
+      'index',
+      'scoped-external',
+    ].sort(),
   ]);
   t.deepEqual(
     sanitizeOrder(['builtin', ['internal', 'parent', 'sibling', 'index']]),
-    ['builtin', ['internal', 'parent', 'sibling', 'index'].sort(), 'external'],
+    [
+      'builtin',
+      ['internal', 'parent', 'sibling', 'index'].sort(),
+      ['external', 'scoped-external'],
+    ]
   );
 });
 
@@ -128,7 +131,7 @@ test('compareImports applies custom order', t => {
   ];
   t.is(
     compareImports(LOCAL_INDEX_MODULE, LOCAL_SIBLING_MODULE_A, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(compareImports(LOCAL_INDEX_MODULE, LOCAL_PARENT_MODULE_A, ORDER), FIRST);
   t.is(compareImports(LOCAL_INDEX_MODULE, INTERNAL_MODULE_A, ORDER), FIRST);
@@ -136,7 +139,7 @@ test('compareImports applies custom order', t => {
   t.is(compareImports(LOCAL_INDEX_MODULE, BUILTIN_MODULE_A, ORDER), FIRST);
   t.is(
     compareImports(LOCAL_SIBLING_MODULE_A, LOCAL_PARENT_MODULE_A, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(compareImports(LOCAL_SIBLING_MODULE_A, INTERNAL_MODULE_A, ORDER), FIRST);
   t.is(compareImports(LOCAL_SIBLING_MODULE_A, EXTERNAL_MODULE_A, ORDER), FIRST);
@@ -159,7 +162,7 @@ test('compareImports applies groups in custom order', t => {
   t.is(compareImports(LOCAL_INDEX_MODULE, EXTERNAL_MODULE_A, ORDER), FIRST);
   t.is(
     compareImports(LOCAL_INDEX_MODULE, LOCAL_SIBLING_MODULE_A, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(compareImports(LOCAL_INDEX_MODULE, LOCAL_PARENT_MODULE_A, ORDER), FIRST);
   t.is(compareImports(LOCAL_INDEX_MODULE, BUILTIN_MODULE_A, ORDER), FIRST);
@@ -182,23 +185,23 @@ test('compareImports applies groups in custom order', t => {
   t.is(compareImports(EXTERNAL_MODULE_B, BUILTIN_MODULE_A, ORDER), FIRST);
   t.is(
     compareImports(LOCAL_SIBLING_MODULE_A, LOCAL_SIBLING_MODULE_B, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(
     compareImports(LOCAL_PARENT_MODULE_A, LOCAL_SIBLING_MODULE_A, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(
     compareImports(LOCAL_PARENT_MODULE_A, LOCAL_SIBLING_MODULE_B, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(
     compareImports(LOCAL_PARENT_MODULE_B, LOCAL_SIBLING_MODULE_A, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(
     compareImports(LOCAL_PARENT_MODULE_B, LOCAL_SIBLING_MODULE_B, ORDER),
-    FIRST,
+    FIRST
   );
   t.is(compareImports(LOCAL_PARENT_MODULE_A, BUILTIN_MODULE_A, ORDER), FIRST);
   t.is(compareImports(LOCAL_PARENT_MODULE_B, BUILTIN_MODULE_A, ORDER), FIRST);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,9 @@
+export const DEFAULT_ORDER = [
+  'builtin',
+  'external',
+  'scoped-external',
+  'internal',
+  'parent',
+  'sibling',
+  'index',
+];

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,28 @@
 import compareImports from './compareImports';
 
 export default (file, api, options) => {
-  const config = options && options instanceof Object && options.sortConfig || {};
+  const config =
+    (options && options instanceof Object && options.sortConfig) || {};
 
   const j = api.jscodeshift;
   const root = j(file.source);
 
   const declarations = root.find(j.ImportDeclaration);
+
+  if (declarations.length <= 1) {
+    return root.toSource();
+  }
+
   const sortedDeclarations = declarations
     .nodes()
     .sort((a, b) =>
-      compareImports(a.source.value, b.source.value, config.groups));
+      compareImports(b.source.value, a.source.value, config.groups)
+    );
 
   declarations.remove();
 
-  return root
-    .find(j.Statement)
-    .at(0)
-    .insertBefore(sortedDeclarations)
-    .toSource();
+  const body = root.get().value.program.body;
+  sortedDeclarations.forEach(dec => body.unshift(dec));
+
+  return root.toSource();
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -15,4 +15,18 @@ testChanged(
   `import fs from 'fs'; import foo from './foo'; let foo = 'bar';`
 );
 
+testChanged(
+  `
+import bar from '../bar';
+import foo from '@foo';
+import fooAbc from '@foo/abc';
+`,
+  `
+import foo from '@foo';
+import fooAbc from '@foo/abc';
+import bar from '../bar';
+`
+);
+
+testUnchanged(`import foo from '@foo/abc'`);
 testUnchanged(`let foo = 'bar';`);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -6,13 +6,13 @@ import sortImports from './';
 const { testChanged, testUnchanged } = testCodemod(
   jscodeshift,
   test,
-  sortImports,
+  sortImports
 );
 
 testChanged(
   'sort imports',
   `import foo from './foo'; import fs from 'fs'; let foo = 'bar';`,
-  `import fs from 'fs'; import foo from './foo'; let foo = 'bar';`,
+  `import fs from 'fs'; import foo from './foo'; let foo = 'bar';`
 );
 
 testUnchanged(`let foo = 'bar';`);

--- a/src/matchers.js
+++ b/src/matchers.js
@@ -3,8 +3,16 @@ import isBuiltinModule from 'is-builtin-module';
 const CURRENT_DIRECTORY_PREFIX = './';
 const PARENT_DIRECTORY_PREFIX = '../';
 
-export const isExternalModule = path =>
-  /^@?[\w-]+$/.test(path) && !isBuiltinModule(path);
+export const isExternalModule = path => {
+  return /^[\w-]+$/.test(path) && !isBuiltinModule(path);
+};
+
+// 1. start with @
+// 2. see if it's a word or '-' (one or more times)
+// 3. see if it optionally ends with a '/'
+// 4. Recursively check again
+export const isScopedExternalModule = path =>
+  /^@(?:[\w-]+\/?[\w-])+$/.test(path) && !isBuiltinModule(path);
 
 export const isInternalModule = path => /^[\w-]+(\/[\w-]+)+$/.test(path);
 

--- a/src/matchers.test.js
+++ b/src/matchers.test.js
@@ -12,6 +12,8 @@ const BUILTIN_MODULE_B = 'http';
 const EXTERNAL_MODULE_A = 'alpha-module';
 const EXTERNAL_MODULE_B = 'beta-module';
 const EXTERNAL_SCOPED_MODULE = '@omega';
+const VALID_EXTERNAL_SCOPED_MODULE_WITH_SLASH = '@foo/abc';
+const INVALID_EXTERNAL_SCOPED_MODULE_WITH_SLASHES = '@foo/////abc';
 const INTERNAL_MODULE_A = 'src/foo';
 const INTERNAL_MODULE_B = 'src/foo/bar/baz';
 const LOCAL_PARENT_MODULE_A = '../delta';
@@ -23,16 +25,18 @@ const LOCAL_SIBLING_MODULE_B = './zeta/eta';
 test('isExternalModule is true only for external modules', t => {
   t.false(isExternalModule(BUILTIN_MODULE_A));
   t.false(isExternalModule(BUILTIN_MODULE_B));
-  t.true(isExternalModule(EXTERNAL_MODULE_A));
-  t.true(isExternalModule(EXTERNAL_MODULE_B));
-  t.true(isExternalModule(EXTERNAL_SCOPED_MODULE));
+  t.false(isExternalModule(EXTERNAL_SCOPED_MODULE));
   t.false(isExternalModule(INTERNAL_MODULE_A));
   t.false(isExternalModule(INTERNAL_MODULE_B));
+  t.false(isExternalModule(INVALID_EXTERNAL_SCOPED_MODULE_WITH_SLASHES));
+  t.false(isExternalModule(LOCAL_INDEX_MODULE));
   t.false(isExternalModule(LOCAL_PARENT_MODULE_A));
   t.false(isExternalModule(LOCAL_PARENT_MODULE_B));
-  t.false(isExternalModule(LOCAL_INDEX_MODULE));
   t.false(isExternalModule(LOCAL_SIBLING_MODULE_A));
   t.false(isExternalModule(LOCAL_SIBLING_MODULE_B));
+  t.false(isExternalModule(VALID_EXTERNAL_SCOPED_MODULE_WITH_SLASH));
+  t.true(isExternalModule(EXTERNAL_MODULE_A));
+  t.true(isExternalModule(EXTERNAL_MODULE_B));
 });
 
 test('isInternalModule is true only for internal modules', t => {
@@ -41,13 +45,15 @@ test('isInternalModule is true only for internal modules', t => {
   t.false(isInternalModule(EXTERNAL_MODULE_A));
   t.false(isInternalModule(EXTERNAL_MODULE_B));
   t.false(isInternalModule(EXTERNAL_SCOPED_MODULE));
-  t.true(isInternalModule(INTERNAL_MODULE_A));
-  t.true(isInternalModule(INTERNAL_MODULE_B));
+  t.false(isInternalModule(INVALID_EXTERNAL_SCOPED_MODULE_WITH_SLASHES));
+  t.false(isInternalModule(LOCAL_INDEX_MODULE));
   t.false(isInternalModule(LOCAL_PARENT_MODULE_A));
   t.false(isInternalModule(LOCAL_PARENT_MODULE_B));
-  t.false(isInternalModule(LOCAL_INDEX_MODULE));
   t.false(isInternalModule(LOCAL_SIBLING_MODULE_A));
   t.false(isInternalModule(LOCAL_SIBLING_MODULE_B));
+  t.false(isInternalModule(VALID_EXTERNAL_SCOPED_MODULE_WITH_SLASH));
+  t.true(isInternalModule(INTERNAL_MODULE_A));
+  t.true(isInternalModule(INTERNAL_MODULE_B));
 });
 
 test('isLocalModuleFromParentDirectory is true only for local parent modules', t => {
@@ -58,11 +64,19 @@ test('isLocalModuleFromParentDirectory is true only for local parent modules', t
   t.false(isLocalModuleFromParentDirectory(EXTERNAL_SCOPED_MODULE));
   t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_A));
   t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_B));
-  t.true(isLocalModuleFromParentDirectory(LOCAL_PARENT_MODULE_A));
-  t.true(isLocalModuleFromParentDirectory(LOCAL_PARENT_MODULE_B));
+  t.false(
+    isLocalModuleFromParentDirectory(
+      INVALID_EXTERNAL_SCOPED_MODULE_WITH_SLASHES
+    )
+  );
   t.false(isLocalModuleFromParentDirectory(LOCAL_INDEX_MODULE));
   t.false(isLocalModuleFromParentDirectory(LOCAL_SIBLING_MODULE_A));
   t.false(isLocalModuleFromParentDirectory(LOCAL_SIBLING_MODULE_B));
+  t.false(
+    isLocalModuleFromParentDirectory(VALID_EXTERNAL_SCOPED_MODULE_WITH_SLASH)
+  );
+  t.true(isLocalModuleFromParentDirectory(LOCAL_PARENT_MODULE_A));
+  t.true(isLocalModuleFromParentDirectory(LOCAL_PARENT_MODULE_B));
 });
 
 test('isLocalModuleCurrentDirectoryIndex is true only for current directory index module', t => {
@@ -71,26 +85,42 @@ test('isLocalModuleCurrentDirectoryIndex is true only for current directory inde
   t.false(isLocalModuleCurrentDirectoryIndex(EXTERNAL_MODULE_A));
   t.false(isLocalModuleCurrentDirectoryIndex(EXTERNAL_MODULE_B));
   t.false(isLocalModuleCurrentDirectoryIndex(EXTERNAL_SCOPED_MODULE));
-  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_A));
-  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_B));
+  t.false(
+    isLocalModuleCurrentDirectoryIndex(
+      INVALID_EXTERNAL_SCOPED_MODULE_WITH_SLASHES
+    )
+  );
   t.false(isLocalModuleCurrentDirectoryIndex(LOCAL_PARENT_MODULE_A));
   t.false(isLocalModuleCurrentDirectoryIndex(LOCAL_PARENT_MODULE_B));
-  t.true(isLocalModuleCurrentDirectoryIndex(LOCAL_INDEX_MODULE));
   t.false(isLocalModuleCurrentDirectoryIndex(LOCAL_SIBLING_MODULE_A));
   t.false(isLocalModuleCurrentDirectoryIndex(LOCAL_SIBLING_MODULE_B));
+  t.false(
+    isLocalModuleCurrentDirectoryIndex(VALID_EXTERNAL_SCOPED_MODULE_WITH_SLASH)
+  );
+  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_A));
+  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_B));
+  t.true(isLocalModuleCurrentDirectoryIndex(LOCAL_INDEX_MODULE));
 });
 
 test('isLocalModuleFromSiblingDirectory is true only for current directory index module', t => {
+  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_A));
+  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_B));
   t.false(isLocalModuleFromSiblingDirectory(BUILTIN_MODULE_A));
   t.false(isLocalModuleFromSiblingDirectory(BUILTIN_MODULE_B));
   t.false(isLocalModuleFromSiblingDirectory(EXTERNAL_MODULE_A));
   t.false(isLocalModuleFromSiblingDirectory(EXTERNAL_MODULE_B));
   t.false(isLocalModuleFromSiblingDirectory(EXTERNAL_SCOPED_MODULE));
-  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_A));
-  t.false(isLocalModuleFromParentDirectory(INTERNAL_MODULE_B));
+  t.false(
+    isLocalModuleFromSiblingDirectory(
+      INVALID_EXTERNAL_SCOPED_MODULE_WITH_SLASHES
+    )
+  );
+  t.false(isLocalModuleFromSiblingDirectory(LOCAL_INDEX_MODULE));
   t.false(isLocalModuleFromSiblingDirectory(LOCAL_PARENT_MODULE_A));
   t.false(isLocalModuleFromSiblingDirectory(LOCAL_PARENT_MODULE_B));
-  t.false(isLocalModuleFromSiblingDirectory(LOCAL_INDEX_MODULE));
+  t.false(
+    isLocalModuleFromSiblingDirectory(VALID_EXTERNAL_SCOPED_MODULE_WITH_SLASH)
+  );
   t.true(isLocalModuleFromSiblingDirectory(LOCAL_SIBLING_MODULE_A));
   t.true(isLocalModuleFromSiblingDirectory(LOCAL_SIBLING_MODULE_B));
 });


### PR DESCRIPTION
Fixes #7 

I added couple of refactors:

1. If we only have 0 or 1 import statements, we should just do nothing
2. Instead of finding the `j.Statement`, insert all import statements before the
program body
3. move around some constants
